### PR TITLE
Phase 1Z-1M hotfix — restore attrs to production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _site
+_config_local.yml
 .sass-cache
 .jekyll-cache
 .jekyll-metadata

--- a/_config.yml
+++ b/_config.yml
@@ -91,15 +91,19 @@ sass:
 exclude:
   - .sass-cache/
   - _handoffs/
-  # Local-serve speed-up: skip the 8556 per-chart attrs JSON files during
-  # Jekyll scan/copy. They're already in _site from the last full build
-  # (or from `export_to_site.py` + a manual `cp -r`); paired with
-  # `keep_files` below so Jekyll won't wipe them on rebuild. Remove this
-  # line if you want a true clean build.
-  - Resource/NoteAttributes/attrs
 
 keep_files:
   - Resource
+  # NOTE on local-serve speed-up:
+  # The 8556 per-chart attrs JSON files under Resource/NoteAttributes/attrs
+  # make `jekyll serve` slow to copy them every rebuild. For LOCAL dev only,
+  # create an untracked `_config_local.yml` with:
+  #   exclude:
+  #     - Resource/NoteAttributes/attrs
+  # and run `bundle exec jekyll serve --config _config.yml,_config_local.yml`.
+  # `keep_files` above prevents Jekyll from wiping them on rebuild even when
+  # excluded. DO NOT put this exclude in the committed _config.yml — it
+  # makes GitHub Pages 404 every attrs file in production.
 #   - .jekyll-cache/
 #   - gemfiles/
 #   - Gemfile


### PR DESCRIPTION
Restores 8556 per-chart attrs JSON to the production build. PR #10 inadvertently committed a local-serve _config.yml exclude that caused all attrs files to 404 on GH Pages while summary.json was served.

## Commits

- c08626852 Hotfix — un-exclude Resource/NoteAttributes/attrs from production build. Moves the local-serve speed-up workflow to an untracked _config_local.yml override.
- b85eb9634 Add _config_local.yml to .gitignore.

## After merge

GH Pages rebuild + deploy → attrs served, per-card density bars work again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)